### PR TITLE
Optimisation du jeu de données téléchargés

### DIFF
--- a/R/imp_corres_aspe_taxref.R
+++ b/R/imp_corres_aspe_taxref.R
@@ -1,10 +1,12 @@
 #' Importer une table de correspondance entre les codes espèces 3 lettres Aspe et leurs codes Taxref
 #'
-#' La donnée ne provient pas de la base ASPE, mais de l'API SANDRE. Comme elle importe l'ensemble du
-#'     référentiel taxonomique, l'opération prend plusieurs dizaines de secondes.
+#' La donnée ne provient pas de la base ASPE, mais de l'API SANDRE. Les données importées ont été 
+#'      filtrer afin de ne pas récupérer l'intégralité du référentiel "Appellation de taxons". Seuls
+#       les Taxons ayant un code alternatif "ASPE" sont nécessaires. Néanmoins, l'opération peut
+#       prendre quelques dizaines de secondes.
 #'
 #' @param url Caractère. URL du jeu de données à télécharger.
-#'     Par défaut "https://api.sandre.eaufrance.fr/referentiels/v1/apt.csv?compress=true"
+#'     Par défaut "https://api.sandre.eaufrance.fr/referentiels/v1/apt.csv?compress=true&filter=<Filter><IS><Field>CodeAlternatifAp/OrgCdAlternatif</Field><Value>ASPE</Value></IS></Filter>"
 #'
 #' @return Dataframe. Table de correspondence.
 #' @export
@@ -18,7 +20,7 @@
 #' \dontrun{
 #' taxref <- imp_corres_aspe_taxref()
 #' }
-imp_corres_aspe_taxref <- function(url = "https://api.sandre.eaufrance.fr/referentiels/v1/apt.csv?compress=true")
+imp_corres_aspe_taxref <- function(url = "https://api.sandre.eaufrance.fr/referentiels/v1/apt.csv?compress=true&filter=<Filter><IS><Field>CodeAlternatifAp/OrgCdAlternatif</Field><Value>ASPE</Value></IS></Filter>")
 
 {
 


### PR DESCRIPTION
L'API du sandre prévoit la possibilité de filtrer le jeu de données téléchargé. Dans ce cas inutile de récupérer l'intégralité du référentiel Taxonomique.

https://www.sandre.eaufrance.fr/api-referentiel#

A tester mais ça doit être plus rapide :)

A titre indicatif , sans filtre la taille des données téléchargées avoisine 3.9 MB et avec filtre 26 KB.