### PR TITLE
Ajout de paramètres dans gg_temp_peuplement

### DIFF
--- a/R/gg_temp_peuplement.R
+++ b/R/gg_temp_peuplement.R
@@ -12,6 +12,8 @@
 #'  protocoles (à ajouter avec la \code{aspe::mef_ajouter_type_protocole()}).
 #'@param var_id_sta Nom de la variable servant à identifier les stations ou
 #'  points. Cette variable donnera les étiquettes du graphique.
+#'@param var_libelle_sta Nom de la variable servant à identifier les libellés
+#'  des stations ou points. Cette variable donnera les étiquettes du graphique.
 #'@param var_especes Variable indiquant l'espèce ou le code espèce.
 #'@param interactif Valeur logique: statique (FALSE) produit avec `ggplot2` ou
 #'  interactif (TRUE) produit avec `ggiraph`.

--- a/R/gg_temp_peuplement.R
+++ b/R/gg_temp_peuplement.R
@@ -1,32 +1,43 @@
-#' Graphique pour représenter l'évolution des effectifs de taxons au cours du temps
+#'Graphique pour représenter l'évolution des effectifs de taxons au cours du
+#'temps
 #'
-#' La fonction permet de visualiser la dynamique des taxons dans le peuplement sur une station. Les taxons sont représentés
-#'     par des points, proportionnels aux effectifs capturés. Les protocoles utilisés sont également représentés. La fonction
-#'     nécessite que le dataframe "ref_espece" de la base ASPE soit chargé.
-#' @param df Dataframe contenant les données des effectifs capturés pour les taxons.  Il doit contenir des variables "effectif"
-#'     et "annee" ainsi qu'une variable permettant d'identifier la station ou le point de
-#'     prélèvement. Il doit également contenir une variable 'pro_libelle' correspondant aux protocoles (à ajouter avec la \code{aspe::mef_ajouter_type_protocole()}).
-#' @param var_id_sta Nom de la variable servant à identifier les stations ou points.
-#'     Cette variable donnera les étiquettes du graphique.
-#' @param var_especes Variable indiquant l'espèce ou le code espèce.
-#' @param interactif Valeur logique: statique (FALSE) produit avec `ggplot2` ou interactif (TRUE) produit avec `ggiraph`.
-#' @param largeur,hauteur Numériques. Dimensions des graphiques interactifs.
-#' @param taxons_ipr Caractère. Indique comment distinguer sur le graphique les noms des espèces participant à l'IPR.
-#'     Peut prendre les valeurs "bold", "italic", "bold.italic", ou par défaut "plain".
-#' @param ... arguments passés à la fonction \code{ggiraph::opts_sizing()}
+#'La fonction permet de visualiser la dynamique des taxons dans le peuplement
+#'sur une station. Les taxons sont représentés par des points, proportionnels
+#'aux effectifs capturés. Les protocoles utilisés sont également représentés. La
+#'fonction nécessite que le dataframe "ref_espece" de la base ASPE soit chargé.
+#'@param df Dataframe contenant les données des effectifs capturés pour les
+#'  taxons.  Il doit contenir des variables "effectif" et "annee" ainsi qu'une
+#'  variable permettant d'identifier la station ou le point de prélèvement. Il
+#'  doit également contenir une variable 'pro_libelle' correspondant aux
+#'  protocoles (à ajouter avec la \code{aspe::mef_ajouter_type_protocole()}).
+#'@param var_id_sta Nom de la variable servant à identifier les stations ou
+#'  points. Cette variable donnera les étiquettes du graphique.
+#'@param var_especes Variable indiquant l'espèce ou le code espèce.
+#'@param interactif Valeur logique: statique (FALSE) produit avec `ggplot2` ou
+#'  interactif (TRUE) produit avec `ggiraph`.
+#'@param largeur,hauteur Numériques. Dimensions des graphiques interactifs.
+#'@param taxons_ipr Caractère. Indique comment distinguer sur le graphique les
+#'  noms des espèces participant à l'IPR. Peut prendre les valeurs "bold",
+#'  "italic", "bold.italic", ou par défaut "plain".
+#'@param longueur_libelle Numérique. longueur maximale (en nombre de caractères)
+#'  du titre du graphique
+#'@param ... arguments passés à la fonction \code{ggiraph::opts_sizing()}
 #'
-#' @return Retourne une liste de graphiques pour les stations ou points, graphiques statiques `ggplot2` ou interactifs `ggiraph`.
-#' @export
+#'@return Retourne une liste de graphiques pour les stations ou points,
+#'  graphiques statiques `ggplot2` ou interactifs `ggiraph`.
+#'@export
 #'
-#' @importFrom dplyr filter rowwise mutate ungroup pull select
-#' @importFrom forcats fct_rev
-#' @importFrom ggiraph geom_point_interactive girafe
-#' @importFrom ggplot2 ggplot aes labs scale_x_continuous xlab scale_size unit theme geom_line scale_shape_manual scale_y_continuous expansion element_blank element_text element_rect
-#' @importFrom ggtext element_markdown
-#' @importFrom patchwork plot_layout
-#' @importFrom purrr map
-#' @importFrom shiny HTML
-#' @importFrom stringr str_wrap
+#'@importFrom dplyr filter rowwise mutate ungroup pull select
+#'@importFrom forcats fct_rev
+#'@importFrom ggiraph geom_point_interactive girafe
+#'@importFrom ggplot2 ggplot aes labs scale_x_continuous xlab scale_size unit
+#'  theme geom_line scale_shape_manual scale_y_continuous expansion
+#'  element_blank element_text element_rect
+#'@importFrom ggtext element_markdown
+#'@importFrom patchwork plot_layout
+#'@importFrom purrr map
+#'@importFrom shiny HTML
+#'@importFrom stringr str_wrap
 #'
 #' @examples
 #' \dontrun{
@@ -69,6 +80,7 @@ gg_temp_peuplement <- function(df,
                                 largeur = 6,
                                 hauteur = 5,
                                 taxons_ipr = "plain",
+                               longueur_libelle = 20,
                                 ...)
 
 {
@@ -111,7 +123,7 @@ gg_temp_peuplement <- function(df,
       dplyr::pull(!!var_libelle_sta) %>%
       na.omit() %>%
       .[1] %>%
-      stringr::str_wrap(20)
+      stringr::str_wrap(longueur_libelle)
 
 
     df_protocole <-

--- a/R/gg_temp_peuplement.R
+++ b/R/gg_temp_peuplement.R
@@ -75,8 +75,8 @@
 #' }
 
 gg_temp_peuplement <- function(df,
-                               var_id_sta,
-                               var_libelle_sta,
+                               var_id_sta = pop_id,
+                               var_libelle_sta = pop_libelle,
                                var_especes = esp_code_alternatif,
                                interactif = FALSE,
                                 largeur = 6,

--- a/man/gg_temp_peuplement.Rd
+++ b/man/gg_temp_peuplement.Rd
@@ -7,8 +7,8 @@ temps}
 \usage{
 gg_temp_peuplement(
   df,
-  var_id_sta,
-  var_libelle_sta,
+  var_id_sta = pop_id,
+  var_libelle_sta = pop_libelle,
   var_especes = esp_code_alternatif,
   interactif = FALSE,
   largeur = 6,

--- a/man/gg_temp_peuplement.Rd
+++ b/man/gg_temp_peuplement.Rd
@@ -2,41 +2,57 @@
 % Please edit documentation in R/gg_temp_peuplement.R
 \name{gg_temp_peuplement}
 \alias{gg_temp_peuplement}
-\title{Graphique pour représenter l'évolution des effectifs de taxons au cours du temps}
+\title{Graphique pour représenter l'évolution des effectifs de taxons au cours du
+temps}
 \usage{
 gg_temp_peuplement(
   df,
+  var_id_sta,
+  var_libelle_sta,
+  var_especes = esp_code_alternatif,
   interactif = FALSE,
   largeur = 6,
   hauteur = 5,
-  var_especes = esp_code_alternatif,
   taxons_ipr = "plain",
+  longueur_libelle = 20,
   ...
 )
 }
 \arguments{
-\item{df}{Dataframe contenant les données des effectifs capturés pour les taxons.  Il doit contenir des variables "effectif"
-et "annee" ainsi qu'une variable permettant d'identifier la station ou le point de
-prélèvement. Il doit également contenir une variable 'pro_libelle' correspondant aux protocoles (à ajouter avec la \code{aspe::mef_ajouter_type_protocole()}).}
+\item{df}{Dataframe contenant les données des effectifs capturés pour les
+taxons.  Il doit contenir des variables "effectif" et "annee" ainsi qu'une
+variable permettant d'identifier la station ou le point de prélèvement. Il
+doit également contenir une variable 'pro_libelle' correspondant aux
+protocoles (à ajouter avec la \code{aspe::mef_ajouter_type_protocole()}).}
 
-\item{interactif}{Valeur logique: statique (FALSE) produit avec \code{ggplot2} ou interactif (TRUE) produit avec \code{ggiraph}.}
-
-\item{largeur, hauteur}{Numériques. Dimensions des graphiques interactifs.}
+\item{var_id_sta}{Nom de la variable servant à identifier les stations ou
+points. Cette variable donnera les étiquettes du graphique.}
 
 \item{var_especes}{Variable indiquant l'espèce ou le code espèce.}
 
-\item{taxons_ipr}{Caractère. Indique comment distinguer sur le graphique les noms des espèces participant à l'IPR.
-Peut prendre les valeurs "bold", "italic", "bold.italic", ou par défaut "plain".}
+\item{interactif}{Valeur logique: statique (FALSE) produit avec \code{ggplot2} ou
+interactif (TRUE) produit avec \code{ggiraph}.}
+
+\item{largeur, hauteur}{Numériques. Dimensions des graphiques interactifs.}
+
+\item{taxons_ipr}{Caractère. Indique comment distinguer sur le graphique les
+noms des espèces participant à l'IPR. Peut prendre les valeurs "bold",
+"italic", "bold.italic", ou par défaut "plain".}
+
+\item{longueur_libelle}{Numérique. longueur maximale (en nombre de caractères)
+du titre du graphique}
 
 \item{...}{arguments passés à la fonction \code{ggiraph::opts_sizing()}}
 }
 \value{
-Retourne une liste de graphiques pour les stations ou points, graphiques statiques \code{ggplot2} ou interactifs \code{ggiraph}.
+Retourne une liste de graphiques pour les stations ou points,
+graphiques statiques \code{ggplot2} ou interactifs \code{ggiraph}.
 }
 \description{
-La fonction permet de visualiser la dynamique des taxons dans le peuplement sur une station. Les taxons sont représentés
-par des points, proportionnels aux effectifs capturés. Les protocoles utilisés sont également représentés. La fonction
-nécessite que le dataframe "ref_espece" de la base ASPE soit chargé.
+La fonction permet de visualiser la dynamique des taxons dans le peuplement
+sur une station. Les taxons sont représentés par des points, proportionnels
+aux effectifs capturés. Les protocoles utilisés sont également représentés. La
+fonction nécessite que le dataframe "ref_espece" de la base ASPE soit chargé.
 }
 \examples{
 \dontrun{

--- a/man/gg_temp_peuplement.Rd
+++ b/man/gg_temp_peuplement.Rd
@@ -28,6 +28,9 @@ protocoles (à ajouter avec la \code{aspe::mef_ajouter_type_protocole()}).}
 \item{var_id_sta}{Nom de la variable servant à identifier les stations ou
 points. Cette variable donnera les étiquettes du graphique.}
 
+\item{var_libelle_sta}{Nom de la variable servant à identifier les libellés
+des stations ou points. Cette variable donnera les étiquettes du graphique.}
+
 \item{var_especes}{Variable indiquant l'espèce ou le code espèce.}
 
 \item{interactif}{Valeur logique: statique (FALSE) produit avec \code{ggplot2} ou

--- a/vignettes/aspe_03_fiche_station.Rmd
+++ b/vignettes/aspe_03_fiche_station.Rmd
@@ -78,7 +78,7 @@ ope_capt <- aspe %>%
 ## Dynamique du peuplement
 
 ```{r, fig.width = 7, fig.height = 5}
-aspe::gg_temp_peuplement(df = ope_capt)
+aspe::gg_temp_peuplement(df = ope_capt, var_id_sta = pop_id, var_libelle_sta = pop_libelle)
 ```
 
 # Etat du milieu


### PR DESCRIPTION
Les modifications proposées permettent d'avoir plus de souplesse sur la variable à utiliser pour identifier les stations de pêche (peut utiliser le code sandre par exemple). 